### PR TITLE
Use correct today for sunrise/sunset times

### DIFF
--- a/twilight.go
+++ b/twilight.go
@@ -40,10 +40,10 @@ func AstronomicalTwilightLength(d time.Time, latitude, longitude float64) time.D
 	return lenToDuration(len)
 }
 
-func riseSetToTime(rise, set float64) (time.Time, time.Time) {
-	y, m, d := time.Now().Date()
+func riseSetToTime(now time.Time, rise, set float64) (time.Time, time.Time) {
+	y, m, d := now.Date()
 
-	today := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+	today := time.Date(y, m, d, 0, 0, 0, 0, now.Location())
 
 	riseDuration := lenToDuration(rise)
 	setDuration := lenToDuration(set)
@@ -53,28 +53,28 @@ func riseSetToTime(rise, set float64) (time.Time, time.Time) {
 
 func SunRiseSet(date time.Time, latitude, longitude float64) (time.Time, time.Time, SunriseStatus) {
 	r, s, status := sunRiseSet(date.Year(), int(date.Month()), date.Day(), longitude, latitude, -35.0/60.0, true)
-	rise, set := riseSetToTime(r, s)
+	rise, set := riseSetToTime(date, r, s)
 
 	return rise, set, status
 }
 
 func CivilTwilight(date time.Time, latitude, longitude float64) (time.Time, time.Time, SunriseStatus) {
 	r, s, status := sunRiseSet(date.Year(), int(date.Month()), date.Day(), longitude, latitude, -6.0, true)
-	rise, set := riseSetToTime(r, s)
+	rise, set := riseSetToTime(date, r, s)
 
 	return rise, set, status
 }
 
 func NauticalTwilight(date time.Time, latitude, longitude float64) (time.Time, time.Time, SunriseStatus) {
 	r, s, status := sunRiseSet(date.Year(), int(date.Month()), date.Day(), longitude, latitude, -12.0, true)
-	rise, set := riseSetToTime(r, s)
+	rise, set := riseSetToTime(date, r, s)
 
 	return rise, set, status
 }
 
 func AstronomicalTwilight(date time.Time, latitude, longitude float64) (time.Time, time.Time, SunriseStatus) {
 	r, s, status := sunRiseSet(date.Year(), int(date.Month()), date.Day(), longitude, latitude, -18.0, true)
-	rise, set := riseSetToTime(r, s)
+	rise, set := riseSetToTime(date, r, s)
 
 	return rise, set, status
 }


### PR DESCRIPTION
Hello @goastro! 

While using your library I noticed that the `today` used for outputting the rise/set times was always "today at time of execution", rather than the same 'today' that was used to calculate the solar movements. I've made a small change to swap over to using the given `date` (including the same timezone given) so that code like the following makes sense:

```go
location, err := time.LoadLocation("Africa/Harare")
if err != nil {
    panic(err)
}

targetTime := time.Date(2022, 6, 1, 10, 42, 0, location)
rise, set, _ := twilight.SunRiseSet(targetTime, -17.82428785142028, 31.049061450287812)

timeToSunset := set.Sub(targetTime)
fmt.Println(timeToSunset) // is hours, not months
```
(There aren't any tests in your repo yet, but if you'd like some written please just let me know)